### PR TITLE
Fix Windows virtual environment code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ For Windows:
 ```shellscript
 python -m venv env
 .\env\Scripts\activate.ps1
-````
+```
 
 For Linux/MacOS:
 


### PR DESCRIPTION
## Summary
- fix incorrect closing code fence in Windows virtual environment instructions

## Testing
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68a4358c780c832c9cf117eea428d934