### PR TITLE
Handle empty environment variables for host lists

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -27,7 +27,10 @@ SECRET_KEY = os.getenv('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DEBUG') == 'True'
 
-ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',')
+# Parse allowed hosts from environment, ignoring empty strings
+ALLOWED_HOSTS = [
+    host for host in os.getenv('ALLOWED_HOSTS', '').split(',') if host
+]
 
 # Application definition
 
@@ -152,7 +155,11 @@ CHANNEL_LAYERS = {
     },
 }
 CORS_ALLOW_ALL_ORIGINS = os.getenv('CORS_ALLOW_ALL_ORIGINS') == 'True'
-CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', '').split(',')
+CORS_ALLOWED_ORIGINS = [
+    origin for origin in os.getenv('CORS_ALLOWED_ORIGINS', '').split(',') if origin
+]
 CORS_ALLOW_CREDENTIALS = os.getenv('CORS_ALLOW_CREDENTIALS') == 'True'
-CSRF_TRUSTED_ORIGINS = os.getenv('CSRF_TRUSTED_ORIGINS', '').split(',')
+CSRF_TRUSTED_ORIGINS = [
+    origin for origin in os.getenv('CSRF_TRUSTED_ORIGINS', '').split(',') if origin
+]
 POKEAPI_BASE_URL = os.getenv('POKEAPI_BASE_URL', 'https://pokeapi.co/api/v2/pokemon')


### PR DESCRIPTION
## Summary
- Safely parse ALLOWED_HOSTS to avoid empty string entries when env vars are missing
- Ignore empty values in CORS and CSRF origin settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a434f66ba0832c816911bd1bf28f1f