### PR TITLE
docs: update API endpoints to plural

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,15 +235,15 @@ python manage.py runserver 8000
 
 The application will be available at:
 
-- Main API: [http://localhost:8000/api](http://localhost:8000)
+- Main API: [http://localhost:8000/api/pokemons/](http://localhost:8000/api/pokemons/)
 - Admin interface: [http://localhost:8000/admin](http://localhost:8000/admin)
 
 ## 📚 API Documentation
 
 ### Endpoints
 
-- `GET /api/pokemon/` - List all Pokemon
-- `GET /api/pokemon/{id}/` - Get Pokemon details
+- `GET /api/pokemons/` - List all Pokemon
+- `GET /api/pokemons/{id}/` - Get Pokemon details
 - `POST /api/import-pokemon/` - Start Pokemon import process
 
 ### WebSocket


### PR DESCRIPTION
## Summary
- update README to use `/api/pokemons/` and `/api/pokemons/{id}/`
- fix README hyperlink to point to plural `pokemons` route

## Testing
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68a435a0bfec832cb2615caaf17169b3