### PR TITLE
Serve static files only in debug

### DIFF
--- a/pokemons/urls.py
+++ b/pokemons/urls.py
@@ -13,5 +13,5 @@ urlpatterns = [
     path('import-pokemon/', ImportPokemonView.as_view(), name='import_pokemon'),
 ]
 
-if not settings.DEBUG:
+if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Summary
- Fix static file routing to only apply in debug mode

## Testing
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*
- `python manage.py shell -c 'from django.test import Client; c=Client(); r=c.get("/static/test.txt"); print(r.status_code); print(b"".join(r.streaming_content).decode())'`


------
https://chatgpt.com/codex/tasks/task_e_68a43597c86c832caad40d8880c8a4cc